### PR TITLE
Allow redirect stdout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/m0lte"]
 	path = libs/m0lte
-	url = git@github.com:M0LTE/WsjtxUdpLib.git
+	url = https://github.com/M0LTE/WsjtxUdpLib.git

--- a/SOTAmatSkimmer/SOTAmatClient.cs
+++ b/SOTAmatSkimmer/SOTAmatClient.cs
@@ -51,13 +51,23 @@ namespace SOTAmatSkimmer
 
             // Update the average DeltaTime we are seeing from these reception reports
             UpdateAvergaeDeltaTime(deltaTime);
-            if (Math.Abs(deltaTimeAverage) > 0.5)
-                Console.ForegroundColor = ConsoleColor.Red;
+            
+            // print just the delta time in front of the debug data if debug is enabled
+            if (config.Debug)
+            {
+                Console.Write($"{deltaTimeAverage:+0.00;-0.00}  ");
+                Console.Out.Flush();
+            }
             else
-                Console.ForegroundColor = ConsoleColor.Green;
-            Console.Write($" Average DeltaTime: {deltaTimeAverage.ToString("+0.00;-0.00")}      ");
-            Console.SetCursorPosition(0, Console.CursorTop);
-            Console.ResetColor();
+            {
+                if (Math.Abs(deltaTimeAverage) > 0.5)
+                    Console.ForegroundColor = ConsoleColor.Red;
+                else
+                    Console.ForegroundColor = ConsoleColor.Green;
+                Console.Write($" Average DeltaTime: {deltaTimeAverage:+0.00;-0.00}      ");
+                Console.SetCursorPosition(0, Console.CursorTop);
+                Console.ResetColor();
+            }
 
             // If the statusMsg is a potential SOTAmat statusMsg, send it to the SOTAmat server
             string pattern = @"^(S(T(M(T)?)?|OTAM(T|AT)?)?M?)\s([0-9A-Z]{1,2}[0-9][0-9A-Z]{1,3})(/[0-9A-Z]{1,4})+$";


### PR DESCRIPTION
Two simple changes:
1, submodule link is https instead of ssh. This should make it easier for anyone trying to build the project.
2. When the debug flag is used, avoid repositioning cursor so if the user redirects stdout, it will not hang the program.

Resolves #1. Resolves #2.