### PR TITLE
Add delta time to SOTAMAT report messages

### DIFF
--- a/SOTAmatSkimmer/SOTAmatClient.cs
+++ b/SOTAmatSkimmer/SOTAmatClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using SOTAmatSkimmer.Utilities;
 
@@ -95,7 +95,7 @@ namespace SOTAmatSkimmer
             if (message.Length == 13 && regex.IsMatch(message))
             {
                 ShowDeltaTime = false;
-                ConsoleHelper.SafeWrite($"Sending SOTAMAT report to server: {message} =>");
+                ConsoleHelper.SafeWrite($"Sending SOTAMAT report to server (DT={deltaTime:F2} s): {message} =>");
                 // Send the statusMsg to the SOTAmat server
                 Task.Run(async () =>
                 {


### PR DESCRIPTION
Update SOTAMAT report console messages to include the delta time for improved timing accuracy visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-5069045d-d2d9-4ff9-9e90-dd441340106a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5069045d-d2d9-4ff9-9e90-dd441340106a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

